### PR TITLE
Correcthtmlpath

### DIFF
--- a/administrator/components/com_templates/Model/TemplateModel.php
+++ b/administrator/components/com_templates/Model/TemplateModel.php
@@ -366,14 +366,14 @@ class TemplateModel extends FormModel
 			$subFolder = $explodeArray['3'];
 			$fileName  = $this->getSafeName($fileName);
 
-			// The old scheme, if a view has a tmpl folder
-			$oldHtmlPath = Path::clean($componentPath . $folder . '/views/' . $subFolder . '/tmpl/');
+			// The new scheme, if a view has a tmpl folder
+			$newHtmlPath = Path::clean($componentPath . $folder . '/tmpl/' . $subFolder . '/');
 
-			if (!$coreFile = Path::find($oldHtmlPath, $fileName))
+			if (!$coreFile = Path::find($newHtmlPath, $fileName))
 			{
-				// The new scheme, the views are directly in the component/tmpl folder
-				$newHtmlPath = Path::clean($componentPath . $folder . '/tmpl/' . $subFolder . '/');
-				$coreFile    = Path::find($newHtmlPath, $fileName);
+				// The old scheme, the views are directly in the component/tmpl folder
+				$oldHtmlPath = Path::clean($componentPath . $folder . '/views/' . $subFolder . '/tmpl/');
+				$coreFile    = Path::find($oldHtmlPath, $fileName);
 
 				return $coreFile;
 			}

--- a/plugins/installer/override/override.php
+++ b/plugins/installer/override/override.php
@@ -121,13 +121,11 @@ class PlgInstallerOverride extends CMSPlugin
 		$size1  = count($after);
 		$size2  = count($before);
 
-		$result = null;
+		$result = array();
 
 		if ($size1 === $size2)
 		{
-			$result = array();
-
-			for ($i = 0; $i <= $size1; $i++)
+			for ($i = 0; $i < $size1; $i++)
 			{
 				if ($after[$i]->coreFile !== $before[$i]->coreFile)
 				{


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla-projects/gsoc18_override_management/issues/25.

### Summary of Changes

I changed the oldhtmlpath to the newhtmlpath

### Testing Instructions

1. Install the component
[com_agosms-1.0.27.zip](https://github.com/joomla-projects/gsoc18_override_management/files/2146772/com_agosms-1.0.27.zip)
and see, that the tmpl-file for the view category is in the subfolder `/views/tmpl` and that there is now tmpl-folder in the "root" of the component.
In the diff view of the component you see the tmpl-file in the subfolder `/components/com_agosms/views/category/tmpl/default.php` for the view category as core file.



2. Make an update via Joomla! updater.
 and see, that there is a tmpl-file for the view category in the subfolder `/views/tmpl` and that there is now a tmpl-folder in the "root" of the component like it should be in Joomla 4.0.

3. Apply this patch and see, that you see the expected result.


### Expected result
In the diff view of the component you see the tmpl-file in the folder `/components/com_agosms/tmpl/category/default.php` for the view category as core file.

### Actual result
In the diff view of the component you see the tmpl-file in the folder `/components/com_agosms/views/tmpl/category/default.php` for the view category as core file.

