### PR TITLE
Fallback if the parameter has not yet been set.

### DIFF
--- a/administrator/components/com_templates/tmpl/template/default_updated_files.php
+++ b/administrator/components/com_templates/tmpl/template/default_updated_files.php
@@ -18,7 +18,12 @@ use Joomla\CMS\Application\ApplicationHelper;
 
 $plugin = PluginHelper::getPlugin('installer', 'override');
 $params = new Registry($plugin->params);
-$result = json_decode($params->get('overridefiles'), JSON_HEX_QUOT);
+if (json_decode($params->get('overridefiles'), JSON_HEX_QUOT))
+{
+	$result = json_decode($params->get('overridefiles'), JSON_HEX_QUOT);
+} else {
+	$result = array();
+}
 ?>
 
 <div class="row">


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Make a new installation of joomla. 


### Testing Instructions
Make a new installation of joomla. Do no update and no installation. Open the view updated files in com_template.


### Expected result
You see the message "Override files are up to date with core files. Nothing is changed in last extension or Joomla update. " if you open the view updated files in com_template.

### Actual result
If you an error if you open the view for updated files in com_template
![templates customise cassiopeia test administration 7](https://user-images.githubusercontent.com/9974686/42598062-4b7f2c66-855b-11e8-80d5-cbd90953c16c.png)



