### PR TITLE
Store Date as UTC and show it in server time zone

### DIFF
--- a/administrator/components/com_templates/Model/TemplateModel.php
+++ b/administrator/components/com_templates/Model/TemplateModel.php
@@ -197,8 +197,24 @@ class TemplateModel extends FormModel
 			$client = ApplicationHelper::getClientInfo($pk->client_id);
 			$path = Path::clean($client->path . '/templates/' . $pk->template . base64_decode($pk->hash_id));
 
+			$tz = new \DateTimeZone(Factory::getApplication()->get('offset'));
+
 			if (file_exists($path))
 			{
+				if ((int) $pk->created_date)
+				{
+					$created_date = new Date($pk->created_date);
+					$created_date->setTimezone($tz);
+					$pk->created_date = $created_date->toSql(true);
+				}
+
+				if ((int) $pk->modified_date)
+				{
+					$modified_date = new Date($pk->modified_date);
+					$modified_date->setTimezone($tz);
+					$pk->modified_date = $modified_date->toSql(true);
+				}
+
 				$results[] = $pk;
 			}
 			elseif ($cleanup)
@@ -206,26 +222,6 @@ class TemplateModel extends FormModel
 				$cleanupIds = array();
 				$cleanupIds[] = $pk->hash_id;
 				$this->publish($cleanupIds, -3, $pk->extension_id);
-			}
-		}
-
-		// Get timezone for converting the created and modified date.
-		$tz = new \DateTimeZone(Factory::getApplication()->get('offset'));
-
-		foreach ($results as $result)
-		{
-			if ((int) $result->created_date)
-			{
-				$created_date = new Date($result->created_date);
-				$created_date->setTimezone($tz);
-				$result->created_date = $created_date->toSql(true);
-			}
-
-			if ((int) $result->modified_date)
-			{
-				$modified_date = new Date($result->modified_date);
-				$modified_date->setTimezone($tz);
-				$result->modified_date = $modified_date->toSql(true);
 			}
 		}
 

--- a/administrator/components/com_templates/Model/TemplateModel.php
+++ b/administrator/components/com_templates/Model/TemplateModel.php
@@ -209,6 +209,26 @@ class TemplateModel extends FormModel
 			}
 		}
 
+		// Get timezone for converting the created and modified date.
+		$tz = new \DateTimeZone(Factory::getApplication()->get('offset'));
+
+		foreach ($results as $result)
+		{
+			if ((int) $result->created_date)
+			{
+				$created_date = new Date($result->created_date);
+				$created_date->setTimezone($tz);
+				$result->created_date = $created_date->toSql(true);
+			}
+
+			if ((int) $result->modified_date)
+			{
+				$modified_date = new Date($result->modified_date);
+				$modified_date->setTimezone($tz);
+				$result->modified_date = $modified_date->toSql(true);
+			}
+		}
+
 		return $results;
 	}
 

--- a/administrator/components/com_templates/Model/TemplateModel.php
+++ b/administrator/components/com_templates/Model/TemplateModel.php
@@ -197,24 +197,8 @@ class TemplateModel extends FormModel
 			$client = ApplicationHelper::getClientInfo($pk->client_id);
 			$path = Path::clean($client->path . '/templates/' . $pk->template . base64_decode($pk->hash_id));
 
-			$tz = new \DateTimeZone(Factory::getApplication()->get('offset'));
-
 			if (file_exists($path))
 			{
-				if ((int) $pk->created_date)
-				{
-					$created_date = new Date($pk->created_date);
-					$created_date->setTimezone($tz);
-					$pk->created_date = $created_date->toSql(true);
-				}
-
-				if ((int) $pk->modified_date)
-				{
-					$modified_date = new Date($pk->modified_date);
-					$modified_date->setTimezone($tz);
-					$pk->modified_date = $modified_date->toSql(true);
-				}
-
 				$results[] = $pk;
 			}
 			elseif ($cleanup)

--- a/administrator/components/com_templates/tmpl/template/default_updated_files.php
+++ b/administrator/components/com_templates/tmpl/template/default_updated_files.php
@@ -57,13 +57,15 @@ $input = Factory::getApplication()->input;
 									<a class="hasTooltip" href="<?php echo Route::_('index.php?option=com_templates&view=template&id=' . (int) $value->extension_id . '&file=' . $value->hash_id); ?>" title="<?php echo Text::_('JACTION_EDIT'); ?>"><?php echo base64_decode($value->hash_id); ?></a>
 								</td>
 								<td>
-									<?php echo $value->created_date; ?>
+									<?php $created_date = $value->created_date; ?>
+									<?php echo $created_date > 0 ? HTMLHelper::_('date', $created_date, 'Y-m-d H:i:s') : '-'; ?>
 								</td>
 								<td>
 									<?php if ($value->modified_date === '0000-00-00 00:00:00') : ?>
 										<span class="badge badge-warning"><?php echo Text::_('COM_TEMPLATES_OVERRIDE_CORE_REMOVED'); ?></span>
 									<?php else : ?>
-										<?php echo $value->modified_date; ?>
+										<?php $modified_date = $value->modified_date; ?>
+										<?php echo $modified_date > 0 ? HTMLHelper::_('date', $modified_date, 'Y-m-d H:i:s') : '-'; ?>
 									<?php endif; ?>
 								</td>
 								<td>

--- a/administrator/components/com_templates/tmpl/template/default_updated_files.php
+++ b/administrator/components/com_templates/tmpl/template/default_updated_files.php
@@ -58,14 +58,14 @@ $input = Factory::getApplication()->input;
 								</td>
 								<td>
 									<?php $created_date = $value->created_date; ?>
-									<?php echo $created_date > 0 ? HTMLHelper::_('date', $created_date, 'Y-m-d H:i:s') : '-'; ?>
+									<?php echo $created_date > 0 ? HTMLHelper::_('date', $created_date, Text::_('DATE_FORMAT_FILTER_DATETIME')) : '-'; ?>
 								</td>
 								<td>
 									<?php if ($value->modified_date === '0000-00-00 00:00:00') : ?>
 										<span class="badge badge-warning"><?php echo Text::_('COM_TEMPLATES_OVERRIDE_CORE_REMOVED'); ?></span>
 									<?php else : ?>
 										<?php $modified_date = $value->modified_date; ?>
-										<?php echo $modified_date > 0 ? HTMLHelper::_('date', $modified_date, 'Y-m-d H:i:s') : '-'; ?>
+										<?php echo $modified_date > 0 ? HTMLHelper::_('date', $modified_date, Text::_('DATE_FORMAT_FILTER_DATETIME')) : '-'; ?>
 									<?php endif; ?>
 								</td>
 								<td>

--- a/plugins/installer/override/override.php
+++ b/plugins/installer/override/override.php
@@ -336,10 +336,8 @@ class PlgInstallerOverride extends CMSPlugin
 		{
 			$insertQuery->clear('values');
 
-			$tz = new \DateTimeZone(Factory::getApplication()->get('offset'));
 			$date = new Date('now');
-			$date->setTimezone($tz);
-			$createdDate = $date->toSql(true);
+			$createdDate = $date->toSql();
 
 			if (empty($pk->coreFile))
 			{


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla-projects/gsoc18_override_management/pull/52#issuecomment-408002797.

### Summary of Changes

The values for modified and created date are stored in UTC, but shown in server time zone.
If your server time zone is Australia 
![global configuration test administration](https://user-images.githubusercontent.com/9974686/43251296-d8d51688-90bf-11e8-9242-7b761b31c32f.png)
you see this time:
![templates customise cassiopeia test administration 4](https://user-images.githubusercontent.com/9974686/43251297-d8f41ea2-90bf-11e8-93b9-223052539907.png)
If your server time zone is in Europe 
![global configuration test administration 1](https://user-images.githubusercontent.com/9974686/43251298-d910b684-90bf-11e8-9c57-21469969066e.png)
you see this time:
![templates customise cassiopeia test administration 5](https://user-images.githubusercontent.com/9974686/43251299-d92c4cd2-90bf-11e8-84a3-f8eaef3c347d.png)

For Europe you see in the view this values:
![templates customise cassiopeia test administration 6](https://user-images.githubusercontent.com/9974686/43251300-d947cee4-90bf-11e8-940c-6242939d9374.png)
In the database the UTC values are stored
![localhost localhost joomla_db a_template_overrides phpmyadmin 4 5 4 1deb2ubuntu2](https://user-images.githubusercontent.com/9974686/43251302-d964eff6-90bf-11e8-874d-ffb167ae09b3.png)
