### PR TITLE
Update en-GB.plg_quickicon_overridecheck.ini

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_quickicon_overridecheck.ini
+++ b/administrator/language/en-GB/en-GB.plg_quickicon_overridecheck.ini
@@ -6,7 +6,7 @@
 PLG_QUICKICON_OVERRIDECHECK="Quick Icon - Joomla! Overrides Update Notification"
 PLG_QUICKICON_OVERRIDECHECK_CHECKING="Checking overrides ..."
 PLG_QUICKICON_OVERRIDECHECK_ERROR="Error on checking overrides."
-PLG_QUICKICON_OVERRIDECHECK_ERROR_ENABLE="Enable installer override plugin."
+PLG_QUICKICON_OVERRIDECHECK_ERROR_ENABLE="Enable <strong>Installer - override</strong> plugin."
 PLG_QUICKICON_OVERRIDECHECK_GROUP_DESC="The group of this plugin (this value is compared with the group value used in <strong>Quick Icons</strong> modules to inject icons)."
 PLG_QUICKICON_OVERRIDECHECK_GROUP_LABEL="Group"
 PLG_QUICKICON_OVERRIDECHECK_OVERRIDEFOUND="%s Override(s) to check."


### PR DESCRIPTION
Capitalise the name of the plugin and use strong to make the name clear from the rest of the text.

I would have preferred to use " instead of < strong but I don't know how to escape that in the JS

So either accept this as is or find a way  to use " 